### PR TITLE
git's .submodules with wrong URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "packages/arch-linux"]
 	path = packages/arch-linux
-	url = https://aur4.archlinux.org/cryptsetup-gui.git
+	url = https://aur.archlinux.org/cryptsetup-gui.git


### PR DESCRIPTION
was pointing to an url that was redirecting, making it fail